### PR TITLE
[Refactor] Allow shared lib use via compile time flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
-# Build Helper
-
-all: build
+all: QRCode.so build
 
 tests: build build-tests
-	./qrcode-tests
+	QRCODE_SHARED_LIB="./QRCode.so" ./qrcode-tests
 
 build:
 	stanza build
@@ -12,3 +10,11 @@ build-tests:
 	stanza build qrcode-tests
 
 .phony: build build-tests
+
+CC=gcc
+SRC=src/Wrapper.c QR-Code-generator/c/qrcodegen.c
+CFLAGS=-IQR-Code-generator/c
+QRCode.so: $(SRC)
+	$(CC) --version
+	$(CC) -v $(SRC) $(CFLAGS) -o $@ -shared -fPIC
+

--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ Cairo is needed to generate the PNG image of the QR code.
 ## Run Tests
 
 ```
-$> stanza build qrcode-tests
 $> make tests
 stanza build
 stanza build qrcode-tests
-./qrcode-tests
+QRCODE_SHARED_LIB="./QRCode.so" ./qrcode-tests
 [Test 1] gen-text-qrcode
 
 

--- a/build-dll.bat
+++ b/build-dll.bat
@@ -1,0 +1,5 @@
+SET PATH=%PATH%;e:\mingw64\mingw64\bin
+SET SRC=./src/Wrapper.c ./QR-Code-generator/c/qrcodegen.c
+SET CFLAGS=-IQR-Code-generator/c
+gcc --version
+gcc -v %SRC% %CFLAGS% -o QRCode.dll -shared -fPIC

--- a/src/Encoder.stanza
+++ b/src/Encoder.stanza
@@ -2,20 +2,7 @@ defpackage QRCode/Encoder :
   import core
   import QRCode/QRCode
   import QRCode/Errors
-
-; Wrapper functions to access macros
-extern get_buffer_len_for_version : (int) -> int
-extern get_buffer_len_MAX : () -> int
-
-extern get_qr_version_min : () -> int
-extern get_qr_version_max : () -> int
-
-; QR Code Generator Functions
-extern qrcodegen_encodeText : (
-  ptr<byte>, ptr<?>, ptr<?>,
-  int, int, int, int, int
-) -> int
-
+  import QRCode/Wrapper
 
 ; ECC Values
 public val ECC_LOW = 0
@@ -42,11 +29,11 @@ public lostanza deftype QRCodeEncoder <: Unique :
   boost : int
 
 public lostanza defn get-qrcode-min-version () -> ref<Int> :
-  val ret = call-c get_qr_version_min()
+  val ret = w_get_qr_version_min()
   return new Int{ret}
 
 public lostanza defn get-qrcode-max-version () -> ref<Int> :
-  val ret = call-c get_qr_version_max()
+  val ret = w_get_qr_version_max()
   return new Int{ret}
 
 public lostanza defn QRCodeEncoder (ecc:ref<Int>, minVersion:ref<Int>, maxVersion:ref<Int>, mask:ref<Int>, boost:ref<Int>) -> ref<QRCodeEncoder> :
@@ -62,12 +49,12 @@ public lostanza defn encode-text (self:ref<QRCodeEncoder>, content:ref<String>) 
   val ret = QRCode()
   val qrBuf = get-buf(ret)
 
-  val maxBufSize = call-c get_buffer_len_MAX()
+  val maxBufSize = w_get_buffer_len_MAX()
   val tempBuf = call-c clib/malloc(maxBufSize)
   if tempBuf == null :
     throw(QRCodeException(String("Failed to Allocate buffer for QR Code")))
 
-  val ok = call-c qrcodegen_encodeText(
+  val ok = w_qrcodegen_encodeText(
     addr!(content.chars),
     tempBuf,
     qrBuf,

--- a/src/QRCode.stanza
+++ b/src/QRCode.stanza
@@ -1,10 +1,8 @@
 defpackage QRCode/QRCode :
   import core
   import QRCode/Errors
-
-extern get_buffer_len_MAX : () -> int
-extern qrcodegen_getSize : (ptr<?>) -> int
-extern qrcodegen_getModule : (ptr<?>, int, int) -> int
+  import QRCode/Wrapper
+  import core/dynamic-library
 
 public lostanza deftype QRCodeFinalizer <: Finalizer :
   buf : ptr<?>
@@ -17,7 +15,7 @@ public lostanza deftype QRCode <: Unique :
   buf : ptr<?>
 
 public lostanza defn QRCode () -> ref<QRCode> :
-  val maxBufSize = call-c get_buffer_len_MAX()
+  val maxBufSize = w_get_buffer_len_MAX()
   ; @NOTE - This buffer gets cleaned up by the QRCode finalizer
   val qrBuf = call-c clib/malloc(maxBufSize) as ptr<?>
   if qrBuf == null :
@@ -30,11 +28,11 @@ public lostanza defn get-buf (self:ref<QRCode>) -> ptr<?> :
   return self.buf
 
 public lostanza defn size (self:ref<QRCode>) -> ref<Int> :
-  val qrSize = call-c qrcodegen_getSize(self.buf)
+  val qrSize = w_qrcodegen_getSize(self.buf)
   return new Int{qrSize}
 
 public lostanza defn active? (self:ref<QRCode>, x:ref<Int>, y:ref<Int>) -> ref<Int> :
-  val active = call-c qrcodegen_getModule(self.buf, x.value, y.value)
+  val active = w_qrcodegen_getModule(self.buf, x.value, y.value)
   return new Int{active}
 
 public defn to-tuple (self:QRCode) -> Tuple<Tuple<Int>> :

--- a/src/Wrapper.stanza
+++ b/src/Wrapper.stanza
@@ -1,0 +1,117 @@
+defpackage QRCode/Wrapper :
+  import core
+  import core/dynamic-library
+
+#if-defined(COMPILE-STATIC):
+
+  extern get_buffer_len_for_version : (int) -> int
+  extern get_buffer_len_MAX : () -> int
+
+  extern get_qr_version_min : () -> int
+  extern get_qr_version_max : () -> int
+
+  ; QR Code Generator Functions
+  extern qrcodegen_encodeText : (
+    ptr<byte>, ptr<?>, ptr<?>,
+    int, int, int, int, int
+  ) -> int
+
+  extern qrcodegen_getSize : (ptr<?>) -> int
+  extern qrcodegen_getModule : (ptr<?>, int, int) -> int
+
+  public lostanza defn w_get_buffer_len_for_version (v:int) -> int :
+    val ret = call-c get_buffer_len_for_version(v)
+    return ret
+
+  public lostanza defn w_get_buffer_len_MAX () -> int :
+    val ret = call-c get_buffer_len_MAX()
+    return ret
+
+  public lostanza defn w_get_qr_version_min () -> int :
+    val ret = call-c get_qr_version_min()
+    return ret
+
+  public lostanza defn w_get_qr_version_max () -> int :
+    val ret = call-c get_qr_version_max()
+    return ret
+
+  public lostanza defn w_qrcodegen_encodeText (text:ptr<byte>, tempBuf:ptr<?>, qrcode:ptr<?>, ecl:int, minVersion:int, maxVersion:int, mask:int, boostEcl:int) -> int :
+    val ret = call-c qrcodegen_encodeText(
+        text, tempBuf, qrcode, ecl, minVersion, maxVersion, mask, boostEcl
+      )
+    return ret
+
+  public lostanza defn w_qrcodegen_getSize (p:ptr<?>) -> int :
+    val ret = call-c qrcodegen_getSize(p)
+    return ret
+
+  public lostanza defn w_qrcodegen_getModule (p:ptr<?>, x:int, y:int) -> int :
+    val ret = call-c qrcodegen_getModule(p, x, y)
+    return ret
+
+#else :
+
+  defn get-shared-lib () -> String :
+    label<String> return:
+      var sharedLib = get-env("QRCODE_SHARED_LIB")
+      match(sharedLib) :
+        (fpath:String) :
+          return(fpath)
+        (x:False):
+          return("./QRCode.dll")
+
+  val shlib = get-shared-lib()
+  val QRLIB = dynamic-library-open(shlib)
+
+  lostanza val p_get_buffer_len_for_version: ptr<( (int) -> int )> =
+    dynamic-library-symbol(QRLIB, String("get_buffer_len_for_version")).address
+
+  public lostanza defn w_get_buffer_len_for_version (v:int) -> int :
+    val ret = call-c [p_get_buffer_len_for_version](v)
+    return ret
+
+  lostanza val p_get_buffer_len_MAX: ptr<( () -> int )> =
+    dynamic-library-symbol(QRLIB, String("get_buffer_len_MAX")).address
+
+  public lostanza defn w_get_buffer_len_MAX () -> int :
+    val ret = call-c [p_get_buffer_len_MAX]()
+    return ret
+
+  lostanza val p_get_qr_version_min: ptr<( () -> int )> =
+    dynamic-library-symbol(QRLIB, String("get_qr_version_min")).address
+
+  public lostanza defn w_get_qr_version_min () -> int :
+    val ret = call-c [p_get_qr_version_min]()
+    return ret
+
+  lostanza val p_get_qr_version_max: ptr<( () -> int )> =
+    dynamic-library-symbol(QRLIB, String("get_qr_version_max")).address
+
+  public lostanza defn w_get_qr_version_max () -> int :
+    val ret = call-c [p_get_qr_version_max]()
+    return ret
+
+  lostanza val p_qrcodegen_encodeText: ptr<( (ptr<byte>, ptr<?>, ptr<?>, int, int, int, int, int) -> int )> =
+    dynamic-library-symbol(QRLIB, String("qrcodegen_encodeText")).address
+
+  public lostanza defn w_qrcodegen_encodeText (text:ptr<byte>, tempBuf:ptr<?>, qrcode:ptr<?>, ecl:int, minVersion:int, maxVersion:int, mask:int, boostEcl:int) -> int :
+    val ret = call-c [p_qrcodegen_encodeText](
+        text, tempBuf, qrcode, ecl, minVersion, maxVersion, mask, boostEcl
+      )
+    return ret
+
+  lostanza val p_qrcodegen_getSize: ptr<( (ptr<?>) -> int )> =
+    dynamic-library-symbol(QRLIB, String("qrcodegen_getSize")).address
+
+  public lostanza defn w_qrcodegen_getSize (p:ptr<?>) -> int :
+    val ret = call-c [p_qrcodegen_getSize](p)
+    return ret
+
+  lostanza val p_qrcodegen_getModule: ptr<( (ptr<?>, int, int) -> int )> =
+    dynamic-library-symbol(QRLIB, String("qrcodegen_getModule")).address
+
+  public lostanza defn w_qrcodegen_getModule (p:ptr<?>, x:int, y:int) -> int :
+    val ret = call-c [p_qrcodegen_getModule](p, x, y)
+    return ret
+
+

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,6 +1,7 @@
 package QRCode/QRCode defined-in "src/QRCode.stanza"
 package QRCode/Encoder defined-in "src/Encoder.stanza"
 package QRCode/Errors defined-in "src/Errors.stanza"
+package QRCode/Wrapper defined-in "src/Wrapper.stanza"
 
 package QRCode/QRCode requires :
   ccfiles :
@@ -17,10 +18,12 @@ package QRCode/tests defined-in "tests/QRCode.stanza"
 build main :
   inputs:
     QRCode/QRCode
+  ;flags: COMPILE-STATIC
   pkg: "pkgs"
 
 build-test qrcode-tests :
   inputs:
     QRCode/tests
+  ;flags: COMPILE-STATIC
   pkg: "pkgs"
   o: "qrcode-tests"


### PR DESCRIPTION
By default, the build now uses a shared library approach to load the QRCode library. The user needs to build the *.DLL or *.so file before using the project. I'm doing it this way so that the JITx repl can properly load the project.

The user can set the `COMPILE-STATIC` flag in the stanza build and force the code to use a static library to load the C functions for the QRcode implementation at build time.

Note that this is supposedly temporary and that a future stanza version will make this unnecessary.

This adds content to the Makefile to build the *.so file and a bat script to build the DLL file on windows assuming mingw64 exists. This is admittedly very hacky right now.